### PR TITLE
Fix: remove "sonar.profile" because was deprecated since SQ 4.5 LTS

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -15,7 +15,6 @@ The following parameters are used to configure the plugin:
 * **inclusions** - Sonar project sources inclusions - sonar.inclusions property
 * **exclusions** - Sonar project sources exclusions - sonar.exclusions property
 * **language** - Sonar project language. Defaults to 'js' - sonar.language property
-* **profile** - Sonar project profile. Defaults to 'node' - sonar.profile property
 * **encoding** - Sonar project encoding. Defaults to 'UTF-8' - sonar.sourceEncoding property
 * **lcovpath** - Sonar project lcov coverage file. Defaults to 'test/coverage/reports/lcov.info' - sonar.javascript.lcov.reportPath property
 

--- a/main.go
+++ b/main.go
@@ -93,12 +93,6 @@ func main() {
 			Value:  "js",
 		},
 		cli.StringFlag{
-			Name:   "profile",
-			Usage:  "Project profile",
-			EnvVar: "PLUGIN_PROFILE",
-			Value:  "node",
-		},
-		cli.StringFlag{
 			Name:   "encoding",
 			Usage:  "Project source encondig",
 			EnvVar: "PLUGIN_ENCODING",
@@ -142,7 +136,6 @@ func run(c *cli.Context) error {
 		Inclusions: c.String("inclusions"),
 		Exclusions: c.String("exclusions"),
 		Language:   c.String("language"),
-		Profile:    c.String("profile"),
 		Encoding:   c.String("encoding"),
 		LcovPath:   c.String("lcovpath"),
 		Debug:      c.Bool("debug"),

--- a/plugin.go
+++ b/plugin.go
@@ -24,7 +24,6 @@ type Plugin struct {
 	Inclusions string
 	Exclusions string
 	Language   string
-	Profile    string
 	Encoding   string
 	LcovPath   string
 	Debug      bool

--- a/sonar-runner.properties.tmpl
+++ b/sonar-runner.properties.tmpl
@@ -8,7 +8,6 @@ sonar.sources={{.Sources}}
 sonar.inclusions={{.Inclusions}}
 sonar.exclusions={{.Exclusions}}
 sonar.language={{.Language}}
-sonar.profile={{.Profile}}
 sonar.sourceEncoding={{.Encoding}}
 sonar.javascript.lcov.reportPath={{.LcovPath}}
 sonar.typescript.lcov.reportPaths={{.LcovPath}}


### PR DESCRIPTION
Remove "sonar.profile" because was deprecated since SQ 4.5 LTS

more info: https://docs.sonarqube.org/display/SONAR/Analysis+Parameters